### PR TITLE
非标准接口

### DIFF
--- a/QuickRun/PluginManager.cs
+++ b/QuickRun/PluginManager.cs
@@ -1,6 +1,7 @@
 ﻿using QuickRun.Plugin;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Windows;
@@ -11,7 +12,7 @@ namespace QuickRun
     {
 
         static HashSet<string> LoadedAssembly = new HashSet<string>();
-        static Dictionary<string, Type> PluginMap = new Dictionary<string, Type>();
+        static Dictionary<string, object> PluginMap = new Dictionary<string, object>();
 
         public static bool LoadPlugin(string path)
         {
@@ -29,22 +30,34 @@ namespace QuickRun
                         string key = pType.GetCustomAttribute<PluginAttribute>()?.Key ?? ("$" + pType.FullName);
                         PluginMap[key] = pType;
                     }
-                    LoadedAssembly.Add(assembly.FullName);
-                    return true;
                 }
                 else
                 {
-                    throw new Exception("not support"); // but soon
+                    var types = assembly.ExportedTypes.Where(t => t.Name.EndsWith(@"QuickRun") || t.Name.EndsWith(@"QuickRunPlugin"));
+                    foreach(var pType in types)
+                    {
+                        var method = pType.GetMethod("Execute", BindingFlags.Public | BindingFlags.Static);
+                        if (method is null) continue;
+                        var pObj = new NonStandardPlugin(method);
+                        var key = pType.GetCustomAttribute<DisplayNameAttribute>()?.DisplayName
+                            ?? pType.FullName.Substring(0, pType.FullName.LastIndexOf("QuickRun"));
+                        key = "$" + key.TrimStart('$');
+                        PluginMap[key] = pObj;
+                    }
                 }
+                LoadedAssembly.Add(assembly.FullName);
+                return true;
             }
             catch { return false; }
         }
 
         public static bool ExecutePlugin(Item item)
         {
-            if (!PluginMap.TryGetValue(item.Key, out var pType))
+            if (!PluginMap.TryGetValue(item.Key, out var pObj))
                 return false;
-            var iplugin = Activator.CreateInstance(pType) as IPlugin;
+            IPlugin iplugin;
+            if (pObj is Type) iplugin = Activator.CreateInstance(pObj as Type) as IPlugin;
+            else iplugin = pObj as IPlugin;
             if(iplugin is Plugin.Plugin plugin)
                 plugin.Arguments = item.Arguments;
             iplugin.Execute();
@@ -54,9 +67,11 @@ namespace QuickRun
         public static bool ExecutePlugin(Item item, IDataObject dragData=null)
         {
             if (dragData == null) return ExecutePlugin(item);
-            if (!PluginMap.TryGetValue(item.Key, out var pType))
+            if (!PluginMap.TryGetValue(item.Key, out var pObj))
                 return false;
-            var iplugin = Activator.CreateInstance(pType) as IPlugin;
+            IPlugin iplugin;
+            if (pObj is Type) iplugin = Activator.CreateInstance(pObj as Type) as IPlugin;
+            else iplugin = pObj as IPlugin;
             if (iplugin is Plugin.Plugin plugin)
             {
                 plugin.Arguments = item.Arguments;
@@ -66,6 +81,21 @@ namespace QuickRun
                 return false;
             iplugin.Execute();
             return true;
+        }
+    }
+
+    class NonStandardPlugin : FileDropPlugin
+    {
+        MethodInfo Method = null;
+
+        public NonStandardPlugin(MethodInfo method)
+        {
+            Method = method;
+        }
+
+        public override void Execute()
+        {
+            Method?.Invoke(null, null);
         }
     }
 }

--- a/QuickRun/PluginManager.cs
+++ b/QuickRun/PluginManager.cs
@@ -88,14 +88,46 @@ namespace QuickRun
     {
         MethodInfo Method = null;
 
+        ParameterInfo[] Parameters = null;
+
+        Exception PluginException = null;
+
         public NonStandardPlugin(MethodInfo method)
         {
             Method = method;
+            Parameters = method.GetParameters();
+            if (Parameters.Length > 2)
+                PluginException = new Exception("参数数量不匹配");
+            if (!Parameters.All(p => (p.ParameterType == typeof(string) || p.ParameterType == typeof(string[]))))
+                PluginException = new Exception("参数类型不匹配");
+        }
+
+        object[] BuildParameters()
+        {
+            if (Parameters.Length == 0)
+                return null;
+            var list = new List<object>();
+            foreach(var param in Parameters)
+            {
+                if (param.ParameterType == typeof(string))
+                    list.Add(Arguments);
+                else if (param.ParameterType == typeof(string[]))
+                    list.Add(FileNames);
+            }
+            return list.ToArray();
         }
 
         public override void Execute()
         {
-            Method?.Invoke(null, null);
+            if (PluginException is null)
+            {
+                var parameters = BuildParameters();
+                Method?.Invoke(null, parameters);
+            }
+            else
+            {
+                throw PluginException;
+            }
         }
     }
 }


### PR DESCRIPTION
用于不依赖QuickRun.Plugin接口的程序集
载入程序集的ExportedTypes中类名以`QuickRun`或`QuickRunPlugin`结尾的类型
支持传入Arguments以及拖文件产生的FileNames; 支持的Execute方法:
```csharp
public static void Execute();
public static void Execute(string[] filenames);
public static void Execute(string arguments);
public static void Execute(string arguments, string[] filenames);
public static void Execute(string[] filenames, arguments);
```
给类名标记DisplayName属性可以作为Key使用, 如果不标记则设为类型的FullName去掉末尾`QuickRunPlugin`

```csharp
namespace MyNameSpace
{
    [DisplayName("$MyKey")]
    public class MyFirstQuickRun {} // 被载入, Key="$MyKey"

    public class MySecondQuickRunPlugin {} // 被载入, Key="$MyNameSpace.MySecond"
}
```

程序内部实际是通过一个继承FileDropPlugin的NonStandardPlugin类实现的