### PR TITLE
分部(外部)配置

### DIFF
--- a/QuickRun/Item.cs
+++ b/QuickRun/Item.cs
@@ -47,6 +47,9 @@ namespace QuickRun
 
         [DisplayName("插件路径")]
         public string Plugin { get; set; } = "";
+
+        [DisplayName("配置路径")]
+        public string DesignPath { get; set; } = "";
     }
 
     public static class ItemUtil

--- a/QuickRun/Main.IO.cs
+++ b/QuickRun/Main.IO.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -77,8 +78,9 @@ namespace QuickRun
                     Name = xparent.GetAttribute("Name", null) ?? "QuickRun"
                 };
                 Folder[sp.Tag.ToString()] = sp;
-                foreach (var xe in xparent.Elements(nameof(Item)))
+                foreach (var ixe in xparent.Elements(nameof(Item)))
                 {
+                    var xe = ixe;
                     var item = xe.FromXElement();
 
                     var btn = new Button() { Content = item.Name };
@@ -90,6 +92,14 @@ namespace QuickRun
 
                     if (!string.IsNullOrEmpty(item.Plugin))
                         plugins.Add(item.Plugin);
+
+                    if (!string.IsNullOrEmpty(item.DesignPath))
+                    {
+                        xe = item.ToXElement();
+                        var design = GetPartialDesign(item.DesignPath);
+                        xe.Add(design.Elements(nameof(Item)).ToArray());
+                        xe.Add(ixe.Elements(nameof(Item)).ToArray());
+                    }
 
                     if (xe.Element(nameof(Item)) != null)
                     {
@@ -114,6 +124,13 @@ namespace QuickRun
 
                 return sp;
             }
+        }
+
+        public XElement GetPartialDesign(string path)
+        {
+            if (!File.Exists(path)) return null;
+            var xe = XElement.Load(path);
+            return xe;
         }
 
         public void Action_LoadStyles(string fileName)

--- a/QuickRun/Main.IO.cs
+++ b/QuickRun/Main.IO.cs
@@ -52,6 +52,7 @@ namespace QuickRun
             }
 
             var plugins = new List<string>();
+            var loadedDesign = new HashSet<string>() { Path.GetFullPath(DesignPath) };
             var Map = new Dictionary<string, Item>();
             var Folder = new Dictionary<string, Panel>();
 
@@ -95,10 +96,14 @@ namespace QuickRun
 
                     if (!string.IsNullOrEmpty(item.DesignPath))
                     {
-                        xe = item.ToXElement();
-                        var design = GetPartialDesign(item.DesignPath);
-                        xe.Add(design.Elements(nameof(Item)).ToArray());
-                        xe.Add(ixe.Elements(nameof(Item)).ToArray());
+                        var path = Path.GetFullPath(item.DesignPath);
+                        if (!loadedDesign.Contains(path) && GetPartialDesign(path) is XElement design)
+                        {
+                            xe = item.ToXElement();
+                            xe.Add(design.Elements(nameof(Item)).ToArray());
+                            xe.Add(ixe.Elements(nameof(Item)).ToArray());
+                            loadedDesign.Add(path);
+                        }
                     }
 
                     if (xe.Element(nameof(Item)) != null)
@@ -129,8 +134,12 @@ namespace QuickRun
         public XElement GetPartialDesign(string path)
         {
             if (!File.Exists(path)) return null;
-            var xe = XElement.Load(path);
-            return xe;
+            try
+            {
+                var xe = XElement.Load(path);
+                return xe;
+            }
+            catch { return null; }
         }
 
         public void Action_LoadStyles(string fileName)


### PR DESCRIPTION
允许配置`DesignPath`属性来加载外部配置, 在加载时会合并进来

例如:
```xml
<!-- design.xml -->
<Item>
  <Item Name="Action1" Uri="..."/>
  <Item Name="Actions" DesignPath="otherdesign.xml"/>
</Item>

<!-- otherdesign.xml -->
<Item>
  <Item Name="OtherAction1" Uri="..."/>
  <Item Name="OtherAction2" Uri="..."/>
  <Item Name="OtherAction2" Uri="..."/>
</Item>
```

加载时会自动合并为:
```xml
<Item>
  <Item Name="Action1" Uri="..."/>
  <Item Name="Actions" DesignPath="otherdesign.xml">
    <Item Name="OtherAction1" Uri="..."/>
    <Item Name="OtherAction2" Uri="..."/>
    <Item Name="OtherAction2" Uri="..."/>
  </Item>
</Item>
```

合并是加载时的临时操作, 不会修改配置文件`design.xml`本身;
另外程序只监控`design.xml`的变动, 如果只修改外部配置, 程序不会动态重载